### PR TITLE
Fix(conditional-fields): normalise initial value before toggle

### DIFF
--- a/conditional-fields/src/index.js
+++ b/conditional-fields/src/index.js
@@ -33,10 +33,14 @@ window.DatoCmsPlugin.init((plugin) => {
     });
   }
 
-  toggleFields(!!plugin.getFieldValue(plugin.fieldPath));
+  function normaliseValue(value) {
+    return invert ? !value : !!value;
+  }
+
+  const initialValue = normaliseValue(plugin.getFieldValue(plugin.fieldPath));
+  toggleFields(initialValue);
 
   plugin.addFieldChangeListener(plugin.fieldPath, (value) => {
-    const show = invert ? !value : !!value;
-    toggleFields(show);
+    toggleFields(normaliseValue(value));
   });
 });


### PR DESCRIPTION
While the field change listener normalises the plugin field value,
the initial value was not normalised before calling `toggleFields`.
This change normalised the value in both situations.