### PR TITLE
Fix missing title field + better errors and names

### DIFF
--- a/inverse-relationships/src/style.sass
+++ b/inverse-relationships/src/style.sass
@@ -13,3 +13,6 @@
 
   &:last-child
     margin-bottom: 0
+
+.error
+  color: #ff5e49


### PR DESCRIPTION
Plugin was breaking when a model did not have a title field. Now if a title field is not set, we use `Record#123`.

If model ID and field ID in settings are misspelled now it alerts you in the widget.