### PR TITLE
FIX: normalise product assuming products have images

### DIFF
--- a/shopify-product/src/components/BrowseProductsModal/styles.module.css
+++ b/shopify-product/src/components/BrowseProductsModal/styles.module.css
@@ -48,6 +48,7 @@
   display: block;
   padding-top: 100%;
   background-size: cover;
+  background-color: var(--light-bg-color);
 }
 
 .product__title {

--- a/shopify-product/src/utils/ShopifyClient.ts
+++ b/shopify-product/src/utils/ShopifyClient.ts
@@ -65,7 +65,7 @@ const normalizeProduct = (product: any): Product => {
 
   return {
     ...product,
-    imageUrl: product.images.edges[0].node.src,
+    imageUrl: product.images.edges[0]?.node.src || '',
   };
 };
 


### PR DESCRIPTION
I was running into an issue where a specific product wasn't showing up when using the modal search. I found that the `normalizeProduct` method was assuming that there was at least 1 image, which ended up throwing an error.

PR includes a default value for the `imageUrl` as well as a light bg colour if an image is not present.