### PR TITLE
Changed content-type from application/json to text/plain

### DIFF
--- a/web-previews/src/entrypoints/SidebarPanel/index.tsx
+++ b/web-previews/src/entrypoints/SidebarPanel/index.tsx
@@ -37,7 +37,7 @@ async function makeRequest(
     const request = await fetch(url.toString(), {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
+        'Content-Type': 'text/plain',
       },
       body: payload,
     });


### PR DESCRIPTION
Changed the content type to text/plain to transform the request into a simple request and avoid firing a preflight. 

Reason for that was that in sveltekit the preflight needed to have a 200 ok status, and sveltekit doesn't allow you to intercept or see OPTIONS requests so I couldn't pass the preflight. 