### PR TITLE
[character-counter]: Allow the addon to be added to field without validation

### DIFF
--- a/character-counter/src/index.tsx
+++ b/character-counter/src/index.tsx
@@ -1,13 +1,15 @@
-import { connect } from 'datocms-plugin-sdk';
+import { FieldType, connect } from 'datocms-plugin-sdk';
 import { render } from './utils/render';
 import FieldExtension from './entrypoints/FieldExtension';
 import 'datocms-react-ui/styles.css';
 
+const FIELDS_TYPES: FieldType[] = ['string', 'text', 'structured_text'];
+
 connect({
   overrideFieldExtensions(field, ctx) {
     if (
-      !['string', 'text', 'structured_text'].includes(
-        field.attributes.field_type,
+      !FIELDS_TYPES.includes(
+        field.attributes.field_type as FieldType,
       )
     ) {
       return;
@@ -25,6 +27,18 @@ connect({
         },
       ],
     };
+  },
+  manualFieldExtensions() {
+    return [
+      {
+        id: 'character-count',
+        name: 'Character counter',
+        type: 'addon',
+        fieldTypes: FIELDS_TYPES,
+        configurable: false,
+        initialHeight: 0,
+      },
+    ];
   },
   renderFieldExtension(id, ctx) {
     return render(<FieldExtension ctx={ctx} />);

--- a/character-counter/src/index.tsx
+++ b/character-counter/src/index.tsx
@@ -19,6 +19,10 @@ connect({
       return;
     }
 
+    if (field.attributes.appearance.addons.find((addon) => addon.field_extension === 'character-count')) {
+      return;
+    }
+
     return {
       addons: [
         {


### PR DESCRIPTION
Hi, as explained in #92, I made it possible for the addon to be added to a field without a length validation.

This could even be expanded in the future to be configurable with a "soft" limit, so the addon turn orange when reaching a configurated threshold.

Fix #92 