### PR TITLE
Show confirmation before clearing table

### DIFF
--- a/table-editor/package.json
+++ b/table-editor/package.json
@@ -2,7 +2,7 @@
   "name": "datocms-plugin-table-editor",
   "description": "A table editor that outputs JSON objects",
   "homepage": "https://github.com/datocms/plugins/tree/master/table-editor#readme",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",

--- a/table-editor/src/components/TableEditor/index.tsx
+++ b/table-editor/src/components/TableEditor/index.tsx
@@ -27,11 +27,13 @@ import {
 } from 'datocms-react-ui';
 import classNames from 'classnames';
 import s from './styles.module.css';
+import {RenderFieldExtensionCtx, RenderModalCtx} from "datocms-plugin-sdk";
 
 type Props = {
   value: Value;
   onChange: (value: Value | null) => void;
   onOpenInFullScreen?: () => void;
+  ctx: RenderFieldExtensionCtx | RenderModalCtx;
 };
 
 function orderedKeys<T extends { [k: string]: unknown }>(
@@ -64,6 +66,7 @@ export default function TableEditor({
   value,
   onChange,
   onOpenInFullScreen,
+  ctx
 }: Props) {
   const defaultColumn = useMemo(
     () => ({
@@ -243,8 +246,28 @@ export default function TableEditor({
     });
   };
 
-  const handleClear = () => {
-    onChange(null);
+  const handleClear = async () => {
+    const result = await ctx.openConfirm({
+      title: 'Clear the table?',
+      content:
+          'Are you sure you want to clear the table and start over? All rows and headers will be destroyed. This cannot be undone.',
+      choices: [
+        {
+          label: 'Yes, clear the table',
+          value: true,
+          intent: 'negative',
+        }
+      ],
+      cancel: {
+        label: 'Go back',
+        value: false,
+      },
+    });
+
+    if (result === true) {
+      onChange(null);
+      await ctx.notice(`Table cleared.`);
+    }
   };
 
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =

--- a/table-editor/src/entrypoints/FieldExtension/index.tsx
+++ b/table-editor/src/entrypoints/FieldExtension/index.tsx
@@ -85,6 +85,7 @@ export default function FieldExtension({ ctx }: Props) {
           value={value}
           onChange={handleUpdate}
           onOpenInFullScreen={handleOpenInFullScreen}
+          ctx={ctx}
         />
       )}
     </Canvas>

--- a/table-editor/src/entrypoints/Modal/index.tsx
+++ b/table-editor/src/entrypoints/Modal/index.tsx
@@ -28,7 +28,7 @@ export default function Modal({ ctx }: Props) {
       {value === null ? (
         <Empty onChange={setValue} />
       ) : (
-        <TableEditor value={value} onChange={setValue} />
+        <TableEditor value={value} onChange={setValue} ctx={ctx} />
       )}
       <div className={s.bar}>
         <Button onClick={handleClose}>Cancel</Button>{" "}


### PR DESCRIPTION
This shows a simple modal when the Clear button is pushed:
![image](https://github.com/datocms/plugins/assets/11964962/1f5512ca-727d-4bfa-86ea-45b5b34dc16e)

Fixes #101 

## Demo
https://github.com/datocms/plugins/assets/11964962/3f83d167-11cd-49cd-bd96-5b3fb8080198

