### PR TITLE
feat(table-editor): improve header empty validation

### DIFF
--- a/table-editor/src/components/EditableHeader/index.tsx
+++ b/table-editor/src/components/EditableHeader/index.tsx
@@ -46,7 +46,7 @@ export default function EditableHeader({
 
   const handleChangeName = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!nameValue) {
+    if (!nameValue?.trim()) {
       ctx.alert('Please provide a valid name');
       return;
     }


### PR DESCRIPTION
Hi

In the Table Editor plugin, the column name is required. However, a whitespace (`" "`) is allowed, which kind of bypasses the validation. This PR blocks whitespaces as valid column names.