### PR TITLE
Update homepage URL for disabled field plugin

### DIFF
--- a/disabled-field/package.json
+++ b/disabled-field/package.json
@@ -2,7 +2,7 @@
   "name": "datocms-plugin-disabled-field",
   "version": "0.1.7",
   "description": "A simple, no-configuration plugin that allows you to disable a field that you don't want anyone to edit. You can apply this plugin to every type of field.",
-  "homepage": "https://github.com/datocms/plugins/tree/master/hidden-field#readme",
+  "homepage": "https://github.com/datocms/plugins/tree/master/disabled-field#readme",
   "keywords": [
     "datocms",
     "datocms-plugin",


### PR DESCRIPTION
The URL was pointing to the old, invalid name (hidden field instead of disabled field)