### PR TITLE
Updated readme for web-previews to discuss the URL query token in Next

### DIFF
--- a/web-previews/README.md
+++ b/web-previews/README.md
@@ -77,6 +77,9 @@ We suggest you look at the code of our [official Next.js Starter Kit](https://gi
 * Route handler called returning the preview links: [`app/api/preview-links/route.tsx`](https://github.com/datocms/nextjs-starter-kit/blob/main/src/app/api/preview-links/route.tsx)
 * Route handlers to toggle Next.js [Draft Mode](https://www.datocms.com/docs/next-js/setting-up-next-js-draft-mode): [`app/api/draft-mode/enable/route.tsx`](https://github.com/datocms/nextjs-starter-kit/blob/main/src/app/api/draft-mode/enable/route.tsx) and [`app/api/draft-mode/disable/route.tsx`](https://github.com/datocms/nextjs-starter-kit/blob/main/src/app/api/draft-mode/disable/route.tsx)
 
+##### Lightweight Authentication
+In our Next.js starter kit, the preview link URLs also include a `token` query parameter that the plugin would send to the webhook receiver, like `https://www.mywebsite.com/api/preview-links?token=some-secret-ish-string`. The `token` is a string of your choice that just has to match in both the plugin settings and [in your frontend's environment variables](https://github.com/datocms/nextjs-starter-kit/blob/main/src/app/api/preview-links/route.tsx#L31-L34). While not encryption, this token is an easy way to limit access to your preview content.
+
 #### Nuxt 3
 
 Below here, you'll find a similar example, adapted for Nuxt. For the purpose of this example, let's say we want to return a link to the webpage that contains the published content.


### PR DESCRIPTION
Small update to clarify that you need to add the secret token to the plugin URL.

Related to https://community.datocms.com/t/general-help-for-datocms/5317/3?u=roger