### PR TITLE
[shopify-product] make image cropping optional

### DIFF
--- a/shopify-product/src/entrypoints/ConfigScreen.tsx
+++ b/shopify-product/src/entrypoints/ConfigScreen.tsx
@@ -108,7 +108,7 @@ export default function ConfigScreen({ ctx }: Props) {
                   />
                 )}
               </Field>
-              <Field name="cropImages">
+              <Field name="disableImageCropping">
                 {({ input, meta: { error } }) => (
                   <SwitchField
                     id="autoApplyToFieldsWithApiKey"

--- a/shopify-product/src/entrypoints/ConfigScreen.tsx
+++ b/shopify-product/src/entrypoints/ConfigScreen.tsx
@@ -111,7 +111,7 @@ export default function ConfigScreen({ ctx }: Props) {
               <Field name="disableImageCropping">
                 {({ input, meta: { error } }) => (
                   <SwitchField
-                    id="autoApplyToFieldsWithApiKey"
+                    id="disableImageCropping"
                     label="Do you want to disable image cropping?"
                     hint="By default we apply a crop center with maxWidth and maxHeight set to 200px"
                     error={error}

--- a/shopify-product/src/entrypoints/ConfigScreen.tsx
+++ b/shopify-product/src/entrypoints/ConfigScreen.tsx
@@ -1,5 +1,5 @@
 import { RenderConfigScreenCtx } from 'datocms-plugin-sdk';
-import { Button, Canvas, TextField, Form, FieldGroup } from 'datocms-react-ui';
+import { Button, Canvas, TextField, Form, FieldGroup, SwitchField } from 'datocms-react-ui';
 import { Form as FormHandler, Field } from 'react-final-form';
 import { ValidConfig, normalizeConfig } from '../types';
 import ShopifyClient from '../utils/ShopifyClient';
@@ -104,6 +104,17 @@ export default function ConfigScreen({ ctx }: Props) {
                     placeholder="shopify_product"
                     error={error}
                     textInputProps={{ monospaced: true }}
+                    {...input}
+                  />
+                )}
+              </Field>
+              <Field name="cropImages">
+                {({ input, meta: { error } }) => (
+                  <SwitchField
+                    id="autoApplyToFieldsWithApiKey"
+                    label="Do you want to disable image cropping?"
+                    hint="By default we apply a crop center with maxWidth and maxHeight set to 200px"
+                    error={error}
                     {...input}
                   />
                 )}

--- a/shopify-product/src/types.ts
+++ b/shopify-product/src/types.ts
@@ -4,6 +4,7 @@ export type ValidConfig = {
   shopifyDomain: string;
   storefrontAccessToken: string;
   autoApplyToFieldsWithApiKey: string;
+  cropImages?: boolean;
   paramsVersion: '2';
 };
 
@@ -33,5 +34,6 @@ export function normalizeConfig(params: Config): ValidConfig {
         : '078bc5caa0ddebfa89cccb4a1baa1f5c',
     shopifyDomain: 'shopifyDomain' in params ? params.shopifyDomain : 'graphql',
     autoApplyToFieldsWithApiKey: '',
+    cropImages: false
   };
 }

--- a/shopify-product/src/types.ts
+++ b/shopify-product/src/types.ts
@@ -4,7 +4,7 @@ export type ValidConfig = {
   shopifyDomain: string;
   storefrontAccessToken: string;
   autoApplyToFieldsWithApiKey: string;
-  cropImages?: boolean;
+  disableImageCropping?: boolean;
   paramsVersion: '2';
 };
 
@@ -34,6 +34,6 @@ export function normalizeConfig(params: Config): ValidConfig {
         : '078bc5caa0ddebfa89cccb4a1baa1f5c',
     shopifyDomain: 'shopifyDomain' in params ? params.shopifyDomain : 'graphql',
     autoApplyToFieldsWithApiKey: '',
-    cropImages: false
+    disableImageCropping: false
   };
 }

--- a/shopify-product/src/utils/ShopifyClient.ts
+++ b/shopify-product/src/utils/ShopifyClient.ts
@@ -103,7 +103,7 @@ const normalizeProducts = (products: any): Product[] =>
 export default class ShopifyClient {
   storefrontAccessToken: string;
   shopifyDomain: string;
-  cropImages?: boolean;
+  disableImageCropping?: boolean;
   constructor({
     storefrontAccessToken,
     shopifyDomain,
@@ -111,7 +111,7 @@ export default class ShopifyClient {
   }: Pick<ValidConfig, 'shopifyDomain' | 'storefrontAccessToken' | 'disableImageCropping'>) {
     this.storefrontAccessToken = storefrontAccessToken;
     this.shopifyDomain = shopifyDomain;
-    this.disableImageCropping = Boolean(cropImages)
+    this.disableImageCropping = Boolean(disableImageCropping)
   }
 
   async productsMatching(query: string) {

--- a/shopify-product/src/utils/ShopifyClient.ts
+++ b/shopify-product/src/utils/ShopifyClient.ts
@@ -59,6 +59,33 @@ const productFragment = `
   }
 `;
 
+const productFragmentWithoutCropping = `
+  id
+  title
+  handle
+  description
+  onlineStoreUrl
+  availableForSale
+  productType
+  priceRange {
+    maxVariantPrice {
+      amount
+      currencyCode
+    }
+    minVariantPrice {
+      amount
+      currencyCode
+    }
+  }
+  images(first: 1) {
+    edges {
+      node {
+        src
+      }
+    }
+  }
+`;
+
 const normalizeProduct = (product: any): Product => {
   if (!product || typeof product !== 'object') {
     throw new Error('Invalid product');
@@ -76,13 +103,15 @@ const normalizeProducts = (products: any): Product[] =>
 export default class ShopifyClient {
   storefrontAccessToken: string;
   shopifyDomain: string;
-
+  cropImages?: boolean;
   constructor({
     storefrontAccessToken,
     shopifyDomain,
-  }: Pick<ValidConfig, 'shopifyDomain' | 'storefrontAccessToken'>) {
+    disableImageCropping
+  }: Pick<ValidConfig, 'shopifyDomain' | 'storefrontAccessToken' | 'disableImageCropping'>) {
     this.storefrontAccessToken = storefrontAccessToken;
     this.shopifyDomain = shopifyDomain;
+    this.disableImageCropping = Boolean(cropImages)
   }
 
   async productsMatching(query: string) {
@@ -92,7 +121,7 @@ export default class ShopifyClient {
             products(first: 10, query: $query) {
               edges {
                 node {
-                  ${productFragment}
+                  ${this.disableImageCropping ? productFragmentWithoutCropping : productFragment}
                 }
               }
           }
@@ -108,7 +137,7 @@ export default class ShopifyClient {
       query: `
         query getProduct($handle: String!) {
           product: productByHandle(handle: $handle) {
-            ${productFragment}
+            ${this.disableImageCropping ? productFragmentWithoutCropping : productFragment}
           }
         }
       `,


### PR DESCRIPTION
I edited the code directly from GitHub so it is likely that there may be errors on the files not directly edited. However, the idea is to make image cropping controllable from the plugin settings, so as not to force it regardless making the plugin unusable in some scenarios where the whole image is needed.