### PR TITLE
fix(web-previews): refresh iframe on record change

### DIFF
--- a/web-previews/src/entrypoints/SidebarFrame/index.tsx
+++ b/web-previews/src/entrypoints/SidebarFrame/index.tsx
@@ -84,7 +84,11 @@ const SidebarFrame = ({ ctx }: PropTypes) => {
     const delayInMs = reloadSettings === true ? 100 : reloadSettings.delayInMs;
 
     setTimeout(forceReload, delayInMs);
-  }, [currentPreviewLink, currentPreviewLink?.reloadPreviewOnRecordUpdate]);
+  }, [
+    ctx.item?.meta.current_version,
+    currentPreviewLink,
+    currentPreviewLink?.reloadPreviewOnRecordUpdate,
+  ]);
 
   return (
     <Canvas ctx={ctx} noAutoResizer={true}>


### PR DESCRIPTION
This PR fixes the `reloadPreviewOnRecordUpdate` functionality. When saving a record, a web preview is now properly refreshed again.

This also fixes the issue that was mentioned by @josephlewisnz here: https://github.com/datocms/plugins/issues/103#issuecomment-2623375197

This bug was introduced one week ago here: https://github.com/datocms/plugins/commit/0841dda9727bcd143511104b0819d31fac64f40a#diff-fffda420cd82f2c018a8b0db157aa97bf374a2c9ad7b232f700f1c4592474867L169