### PR TITLE
Add expanded fields to Web Previews plugin

### DIFF
--- a/web-previews/README.md
+++ b/web-previews/README.md
@@ -66,6 +66,12 @@ The plugin will show all the preview links that are returned. If you want to mak
 }
 ```
 
+## Expanded fields
+
+When granting the plugin the permission to perform actions and API calls on behalf of the logged-in user, you can configure which single link fields should be automatically expanded with their full record data in the webhook payload. This is useful when you need attributes like `slug` from linked records to construct your preview URLs.
+
+Instead of receiving just the linked record ID, you'll receive the complete linked record. Configure expanded fields in the plugin settings by entering the API keys of single link fields you want to resolve.
+
 ## Implementation examples
 
 If you have built alternative endpoint implementations for other frameworks/SSGs, please open up a PR to this plugin and share it with the community!

--- a/web-previews/package-lock.json
+++ b/web-previews/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "datocms-plugin-web-previews",
-  "version": "1.0.20",
+  "version": "1.0.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-plugin-web-previews",
-      "version": "1.0.20",
+      "version": "1.0.26",
       "license": "GPLv3",
       "dependencies": {
+        "@datocms/cma-client": "^5.0.1",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@types/lodash-es": "^4.17.12",
@@ -498,19 +499,19 @@
       }
     },
     "node_modules/@datocms/cma-client": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/@datocms/cma-client/-/cma-client-3.3.15.tgz",
-      "integrity": "sha512-NlsdJMFjvZ5WtORVVoOzo5TjQNdzDysHj2mUtY9qQqh2YH6VhAYKv5kdKtasdanV97XofK8PiDe4uthSlqVtjg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@datocms/cma-client/-/cma-client-5.0.1.tgz",
+      "integrity": "sha512-D5cIOtH6uwH9GECGWOXvq4VlZov9O6EFwDbm+TNZsdUwY5vFuHFkl1UlP9co4hZvR2fwIZ1zW4K51bYIKOGm9A==",
       "license": "MIT",
       "dependencies": {
-        "@datocms/rest-client-utils": "^3.3.15",
+        "@datocms/rest-client-utils": "^5.0.0",
         "uuid": "^9.0.1"
       }
     },
     "node_modules/@datocms/rest-client-utils": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/@datocms/rest-client-utils/-/rest-client-utils-3.3.15.tgz",
-      "integrity": "sha512-QFxnsaV9rtkojP8IoW5ucqpLtpvJOxCanTrtaYf6SOR20cYAhMT34Blf+BtObyeK4IaLfYYyR2IQ3EBqR4R3xQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@datocms/rest-client-utils/-/rest-client-utils-5.0.0.tgz",
+      "integrity": "sha512-yQSlxp2A9zmXdHgXWQSDPKVY4BRcyQS2S+tsVfTAfrknrTZk6VrCMqumfblpbHJ4nroBxxgWUkA0EaVsyu8Uag==",
       "license": "MIT",
       "dependencies": {
         "async-scheduler": "^1.4.4"
@@ -1488,6 +1489,18 @@
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.10.0"
       }
     },
     "node_modules/@types/parse-json": {
@@ -2545,6 +2558,15 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",

--- a/web-previews/package.json
+++ b/web-previews/package.json
@@ -21,9 +21,13 @@
     "title": "Web Previews",
     "previewImage": "docs/video.mp4",
     "coverImage": "docs/cover.png",
-    "entryPoint": "dist/index.html"
+    "entryPoint": "dist/index.html",
+    "permissions": [
+      "currentUserAccessToken"
+    ]
   },
   "dependencies": {
+    "@datocms/cma-client": "^5.0.1",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@types/lodash-es": "^4.17.12",

--- a/web-previews/src/entrypoints/ConfigScreen/index.tsx
+++ b/web-previews/src/entrypoints/ConfigScreen/index.tsx
@@ -127,6 +127,18 @@ export default function ConfigScreen({ ctx }: PropTypes) {
             return ruleErrors;
           });
 
+          errors.expandedFields = values.expandedFields?.map((fieldName) => {
+            if (!fieldName || fieldName.trim() === '') {
+              return 'Field name required!';
+            }
+            
+            if (values.expandedFields.filter(f => f === fieldName).length > 1) {
+              return 'Field name must be unique!';
+            }
+            
+            return undefined;
+          }) || [];
+
           return errors;
         }}
         onSubmit={async (values) => {
@@ -307,6 +319,59 @@ export default function ConfigScreen({ ctx }: PropTypes) {
                 )}
               </FieldArray>
             </Section>
+            {ctx.currentUserAccessToken && (
+              <Section
+                title="Expanded Fields"
+                headerStyle={{ marginBottom: 'var(--spacing-m)' }}
+              >
+                <p>
+                  Specify which linked fields should be automatically expanded with their full record data in the webhook payload.
+                  Enter the field names (API keys) that contain single link references you want to resolve.
+                </p>
+                <FieldArray<string> name="expandedFields">
+                  {({ fields }) => (
+                    <FieldGroup>
+                    {fields.map((name, index) => (
+                      <div key={name} className={s.grid}>
+                        <div className={s.headerGrid}>
+                          <div>
+                            <Field name={`${name}`}>
+                              {({ input, meta: { error } }) => (
+                                <TextField
+                                  id={`expandedField${index}`}
+                                  label="Field API key"
+                                  placeholder="e.g. category, author, etc."
+                                  hint="API key of a single link field"
+                                  required
+                                  error={error}
+                                  {...input}
+                                />
+                              )}
+                            </Field>
+                          </div>
+                        </div>
+                        <Button
+                          type="button"
+                          buttonType="negative"
+                          buttonSize="xxs"
+                          leftIcon={<FontAwesomeIcon icon={faTrash} />}
+                          onClick={() => fields.remove(index)}
+                        />
+                      </div>
+                    ))}
+                      <Button
+                        type="button"
+                        buttonSize="xxs"
+                        leftIcon={<FontAwesomeIcon icon={faPlus} />}
+                        onClick={() => fields.push('')}
+                      >
+                        Add field to expand
+                      </Button>
+                    </FieldGroup>
+                  )}
+                </FieldArray>
+              </Section>
+            )}
             <Section title="Web Previews sidebar">
               <FieldGroup>
                 <Field name="defaultSidebarWidth">

--- a/web-previews/src/types.ts
+++ b/web-previews/src/types.ts
@@ -27,6 +27,7 @@ export type Parameters = {
   defaultSidebarWidth?: string;
   iframeAllowAttribute?: string;
   defaultViewports?: RawViewport[];
+  expandedFields?: string[];
 };
 
 export type Viewport = {
@@ -49,6 +50,7 @@ export type NormalizedParameters = {
   defaultSidebarWidth: number;
   iframeAllowAttribute: string | undefined;
   defaultViewports: Viewport[];
+  expandedFields: string[];
 };
 
 const DEFAULT_VIEWPORTS: readonly Viewport[] = [
@@ -66,6 +68,7 @@ export function normalizeParameters({
   defaultSidebarWidth,
   iframeAllowAttribute,
   defaultViewports,
+  expandedFields,
 }: Parameters): NormalizedParameters {
   return {
     frontends:
@@ -91,6 +94,7 @@ export function normalizeParameters({
           : Number.parseInt(viewport.height),
       icon: viewport.icon as IconName,
     })) || [...DEFAULT_VIEWPORTS],
+    expandedFields: expandedFields || [],
   };
 }
 


### PR DESCRIPTION
When implementing the Web Previews plugin, I often need to fetch linked records using the DatoCMS API to access attributes like `slug` for constructing preview URLs. 

For example, if a blog article is constructed as follows, we need to manually fetch the `category.slug` via the category ID returned by the webhook payload:
`/blog/{category.slug}/{slug}`

This adds complexity and requires additional API calls in the webhook implementation.

This PR aims to eliminate this issue by allowing users to configure which single link fields should be automatically expanded with their full record data in the webhook payload.

Here's what this new option looks like when configuring the Web Previews plugin:

<img width="2062" height="1048" alt="Screenshot 2025-09-12 at 12 07 27" src="https://github.com/user-attachments/assets/d8dbcddd-08db-48c3-93c3-306880408408" />

## What it does
- Automatically resolves selected linked records with full data in webhook payload
- Useful for accessing attributes like `slug` for preview URL construction

## Changes
- Add configurable expanded fields in plugin settings
- Automatic linked record resolution using DatoCMS CMA client
- Requires "Perform actions and API calls on behalf of logged-in user" permission (otherwise not displayed)

## Usage
1. Grant the plugin the "Perform actions and API calls on behalf of logged-in user" permission (users will need to re-install the Web Previews plugin)
2. Configure which single link fields to expand in plugin settings
3. Webhook payload will include full linked record data instead of just IDs