### PR TITLE
Support keywords localization in SEO analysis plugin

### DIFF
--- a/seo-readability-analysis/README.md
+++ b/seo-readability-analysis/README.md
@@ -14,7 +14,35 @@ Once the plugin is installed, please configure your Frontend metadata endpoint U
 
 This plugin is meant to be used on JSON fields, so please assign it to some JSON fields in in your project.
 
-The plugin will store information inside the JSON field using this structure:
+### Storage format
+
+The plugin adapts its storage format based on whether your DatoCMS project uses multiple locales.
+
+**For projects with multiple locales**, the plugin will store information inside the JSON field using this structure:
+
+```json
+{
+  "en": {
+    "keyword": "food shows",
+    "synonyms": "cooking shows, culinary demonstrations",
+    "relatedKeywords": [
+      {
+        "keyword": "food",
+        "synonyms": ""
+      }
+    ]
+  },
+  "it": {
+    "keyword": "programmi di cucina",
+    "synonyms": "spettacoli di cucina",
+    "relatedKeywords": []
+  }
+}
+```
+
+This allows you to set different SEO keywords for each locale in your project.
+
+**For projects with a single locale**, the plugin will store information inside the JSON field using this structure:
 
 ```json
 {


### PR DESCRIPTION
Hello,

When working with multilingual projects, SEO keywords in the SEO/Readability Analysis plugin are currently shared across all locales.

This means content editors have to re-enter keywords every time they switch languages - entering "food shows" in English, then switching to Italian and having to replace it with "programmi di cucina", and so on for every locale.

**Solution**
This PR adds locale-specific keyword storage for multilingual projects. Keywords, synonyms, and related keywords are now saved per locale:

```
{
  "en": { "keyword": "food shows", "synonyms": "...", "relatedKeywords": [] },
  "fr": { "keyword": "émissions culinaires", "synonyms": "...", "relatedKeywords": [] }
}
```

Single-locale projects continue using the flat format for simplicity and backwards compatibility:

```
{ "keyword": "food shows", "synonyms": "...", "relatedKeywords": [] }
````

With this change, editors can now set keywords once per locale and have them persist when switching between languages. No more copying and pasting the same keywords across locales or losing track of what was already optimized for each language.

Please let me know if you have any feedback or whether this could be done in another way! 🙏 