### PR TITLE
Fix for AI translate not correctly copying over empty fields on new locale creation

### DIFF
--- a/ai-translations/CHANGELOG.md
+++ b/ai-translations/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- 3.4.2: Fix for optional & empty localized fields not getting correctly copied to new locales. Empty optional fields will now be null in the new locale, while required fields that cannot be translated will be a direct copy of the source locale's value.
 - 3.4.1: Fixed several DeepL bugs from 3.4.0: glossary loading no longer races on duplicate fetches, error detection survives DeepL rewording their messages, and glossary caches now reset when you change API keys. Also fixed a latent bug where empty AI responses crashed translations instead of falling back to the original text.
 - 3.4.0: Added better error handling for the CORS proxy and DeepL-specific configuration UI improvements. Selecting a glossary to use should be easier now.
 - Prior to 3.4.0: No changelog was kept.

--- a/ai-translations/package-lock.json
+++ b/ai-translations/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datocms-plugin-ai-translations",
-  "version": "3.3.4",
+  "version": "3.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-plugin-ai-translations",
-      "version": "3.3.4",
+      "version": "3.4.2",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
         "@datocms/cma-client-browser": "^5.3.0",

--- a/ai-translations/package.json
+++ b/ai-translations/package.json
@@ -1,7 +1,7 @@
 {
   "name": "datocms-plugin-ai-translations",
   "homepage": "https://github.com/datocms/plugins/tree/master/ai-translations#readme",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "author": "DatoCMS <support@datocms.com>",
   "description": "Translate fields and records directly on DatoCMS using AI",
   "keywords": [

--- a/ai-translations/src/utils/schemaRepository.ts
+++ b/ai-translations/src/utils/schemaRepository.ts
@@ -11,6 +11,7 @@
 
 import type { buildClient } from '@datocms/cma-client-browser';
 import { SchemaRepository } from '@datocms/cma-client-browser';
+import type { FieldValidators } from './translation/SharedFieldUtils';
 
 /**
  * Field metadata shape used by TranslateField.ts for block field lookups.
@@ -19,7 +20,7 @@ export type BlockFieldMeta = {
   editor: string;
   id: string;
   localized?: boolean;
-  validators?: unknown;
+  validators?: FieldValidators;
 };
 
 /**
@@ -113,6 +114,7 @@ export async function buildFieldTypeDictionaryFromRepo(
       editor: field.appearance.editor,
       id: field.id,
       isLocalized: field.localized,
+      validators: field.validators,
     };
     return acc;
   }, {} as FieldTypeDictionary);

--- a/ai-translations/src/utils/translation/ItemsDropdownUtils.test.ts
+++ b/ai-translations/src/utils/translation/ItemsDropdownUtils.test.ts
@@ -82,7 +82,7 @@ describe('ItemsDropdownUtils', () => {
   });
 
   describe('buildTranslatedUpdatePayload', () => {
-    it('leaves disabled fields untouched in the payload', async () => {
+    it('includes disabled fields with null fallback in the payload (locale sync)', async () => {
       vi.mocked(translateFieldValue).mockResolvedValue('Ciao');
 
       const result = await buildTranslatedUpdatePayload(
@@ -98,11 +98,17 @@ describe('ItemsDropdownUtils', () => {
 
       expect(result.payload).toEqual({
         title: { en: 'Hello', de: 'Hallo', it: 'Ciao' },
+        slug: { en: 'hello-world', de: 'hallo-welt', it: null },
+        body: {
+          en: [{ type: 'paragraph', children: [{ text: 'Body text' }] }],
+          de: [{ type: 'paragraph', children: [{ text: 'Vorhanden' }] }],
+          it: null,
+        },
       });
       expect(result.warnings).toEqual([]);
     });
 
-    it('leaves excluded fields untouched in the payload', async () => {
+    it('includes excluded fields with null fallback in the payload (locale sync)', async () => {
       vi.mocked(translateFieldValue).mockResolvedValue('Ciao');
 
       const result = await buildTranslatedUpdatePayload(
@@ -117,6 +123,7 @@ describe('ItemsDropdownUtils', () => {
       );
 
       expect(result.payload).toEqual({
+        title: { en: 'Hello', de: 'Hallo', it: null },
         slug: { en: 'hello-world', de: 'hallo-welt', it: 'Ciao' },
         body: {
           en: [{ type: 'paragraph', children: [{ text: 'Body text' }] }],
@@ -152,10 +159,86 @@ describe('ItemsDropdownUtils', () => {
         de: 'Hallo',
         it: 'Ciao',
       });
-      expect(result.payload.slug).toBeUndefined();
+      expect(result.payload.slug).toEqual({
+        en: 'hello-world',
+        de: 'hallo-welt',
+        it: null,
+      });
       expect(result.warnings).toContain(
         'Field "slug" was skipped: Translated slug is empty after normalization.',
       );
+    });
+
+    it('copies source value for required non-translatable fields', async () => {
+      vi.mocked(translateFieldValue).mockResolvedValue('Ciao');
+
+      const dictWithRequired = {
+        title: {
+          editor: 'single_line',
+          id: 'field-title',
+          isLocalized: true,
+          validators: { required: {} },
+        },
+        slug: { editor: 'slug', id: 'field-slug', isLocalized: true },
+        body: { editor: 'structured_text', id: 'field-body', isLocalized: true },
+      };
+
+      const result = await buildTranslatedUpdatePayload(
+        record,
+        'en',
+        'it',
+        dictWithRequired,
+        provider,
+        { ...pluginParams, translationFields: ['slug', 'structured_text'] },
+        'access-token',
+        'main',
+      );
+
+      // title is required but not translatable → copies source value
+      expect(result.payload.title).toEqual({
+        en: 'Hello',
+        de: 'Hallo',
+        it: 'Hello',
+      });
+      // slug and body are translated normally
+      expect(result.payload.slug).toEqual({
+        en: 'hello-world',
+        de: 'hallo-welt',
+        it: 'Ciao',
+      });
+    });
+
+    it('skips fallback for fields that already have the target locale', async () => {
+      vi.mocked(translateFieldValue).mockResolvedValue('Ciao');
+
+      const recordWithExistingLocale: DatoCMSRecordFromAPI = {
+        id: 'record-2',
+        item_type: { id: 'item-type-1' },
+        title: { en: 'Hello', it: 'Existing' },
+        slug: { en: 'hello-world' },
+        body: {
+          en: [{ type: 'paragraph', children: [{ text: 'Body text' }] }],
+        },
+      };
+
+      const result = await buildTranslatedUpdatePayload(
+        recordWithExistingLocale,
+        'en',
+        'it',
+        fieldTypeDictionary,
+        provider,
+        { ...pluginParams, translationFields: ['structured_text'] },
+        'access-token',
+        'main',
+      );
+
+      // title already has 'it' → not overwritten
+      expect(result.payload.title).toBeUndefined();
+      // slug does not have 'it' → gets null fallback
+      expect(result.payload.slug).toEqual({
+        en: 'hello-world',
+        it: null,
+      });
     });
   });
 });

--- a/ai-translations/src/utils/translation/ItemsDropdownUtils.test.ts
+++ b/ai-translations/src/utils/translation/ItemsDropdownUtils.test.ts
@@ -4,6 +4,7 @@ import {
   buildTranslatedUpdatePayload,
   type DatoCMSRecordFromAPI,
   shouldTranslateField,
+  stripBlockIds,
 } from './ItemsDropdownUtils';
 
 vi.mock('./TranslateField', () => ({
@@ -169,8 +170,36 @@ describe('ItemsDropdownUtils', () => {
       );
     });
 
-    it('copies source value for required non-translatable fields', async () => {
+    it('copies source value for required non-block fields, strips IDs for required block fields', async () => {
       vi.mocked(translateFieldValue).mockResolvedValue('Ciao');
+
+      const bodyWithBlocks = {
+        en: [
+          {
+            type: 'item',
+            id: 'block-1',
+            attributes: { title: 'Hello' },
+            relationships: {
+              item_type: { data: { id: 'model-1', type: 'item_type' } },
+            },
+          },
+        ],
+        de: [
+          {
+            type: 'item',
+            id: 'block-2',
+            attributes: { title: 'Hallo' },
+            relationships: {
+              item_type: { data: { id: 'model-1', type: 'item_type' } },
+            },
+          },
+        ],
+      };
+
+      const recordWithBlocks: DatoCMSRecordFromAPI = {
+        ...record,
+        body: bodyWithBlocks,
+      };
 
       const dictWithRequired = {
         title: {
@@ -180,31 +209,68 @@ describe('ItemsDropdownUtils', () => {
           validators: { required: {} },
         },
         slug: { editor: 'slug', id: 'field-slug', isLocalized: true },
-        body: { editor: 'structured_text', id: 'field-body', isLocalized: true },
+        body: {
+          editor: 'structured_text',
+          id: 'field-body',
+          isLocalized: true,
+          validators: { required: {} },
+        },
       };
 
       const result = await buildTranslatedUpdatePayload(
-        record,
+        recordWithBlocks,
         'en',
         'it',
         dictWithRequired,
         provider,
-        { ...pluginParams, translationFields: ['slug', 'structured_text'] },
+        { ...pluginParams, translationFields: ['slug'] },
         'access-token',
         'main',
       );
 
-      // title is required but not translatable → copies source value
+      // title is required non-block → copies source value
       expect(result.payload.title).toEqual({
         en: 'Hello',
         de: 'Hallo',
         it: 'Hello',
       });
-      // slug and body are translated normally
+      // slug is translated normally
       expect(result.payload.slug).toEqual({
         en: 'hello-world',
         de: 'hallo-welt',
         it: 'Ciao',
+      });
+      // body is required block field → copies source blocks with IDs stripped
+      expect(result.payload.body).toEqual({
+        en: [
+          {
+            type: 'item',
+            id: 'block-1',
+            attributes: { title: 'Hello' },
+            relationships: {
+              item_type: { data: { id: 'model-1', type: 'item_type' } },
+            },
+          },
+        ],
+        de: [
+          {
+            type: 'item',
+            id: 'block-2',
+            attributes: { title: 'Hallo' },
+            relationships: {
+              item_type: { data: { id: 'model-1', type: 'item_type' } },
+            },
+          },
+        ],
+        it: [
+          {
+            type: 'item',
+            attributes: { title: 'Hello' },
+            relationships: {
+              item_type: { data: { id: 'model-1', type: 'item_type' } },
+            },
+          },
+        ],
       });
     });
 
@@ -239,6 +305,81 @@ describe('ItemsDropdownUtils', () => {
         en: 'hello-world',
         it: null,
       });
+    });
+  });
+
+  describe('stripBlockIds', () => {
+    it('strips id from top-level block objects', () => {
+      const block = {
+        type: 'item',
+        id: 'block-1',
+        attributes: { title: 'Hello' },
+        relationships: {
+          item_type: { data: { id: 'model-1', type: 'item_type' } },
+        },
+      };
+      expect(stripBlockIds(block)).toEqual({
+        type: 'item',
+        attributes: { title: 'Hello' },
+        relationships: {
+          item_type: { data: { id: 'model-1', type: 'item_type' } },
+        },
+      });
+    });
+
+    it('recursively strips ids from nested blocks in arrays', () => {
+      const value = [
+        {
+          type: 'item',
+          id: 'outer-1',
+          attributes: {
+            nested: [
+              {
+                type: 'item',
+                id: 'inner-1',
+                attributes: { text: 'Deep' },
+              },
+            ],
+          },
+        },
+      ];
+      expect(stripBlockIds(value)).toEqual([
+        {
+          type: 'item',
+          attributes: {
+            nested: [
+              {
+                type: 'item',
+                attributes: { text: 'Deep' },
+              },
+            ],
+          },
+        },
+      ]);
+    });
+
+    it('leaves non-block objects untouched', () => {
+      const value = { type: 'paragraph', children: [{ text: 'Hello' }] };
+      expect(stripBlockIds(value)).toEqual(value);
+    });
+
+    it('preserves id on non-block objects (e.g., relationships)', () => {
+      const value = {
+        type: 'item_type',
+        id: 'model-1',
+      };
+      // type is not "item", so id should remain
+      expect(stripBlockIds(value)).toEqual({
+        type: 'item_type',
+        id: 'model-1',
+      });
+    });
+
+    it('passes through primitives and null', () => {
+      expect(stripBlockIds(null)).toBeNull();
+      expect(stripBlockIds(undefined)).toBeUndefined();
+      expect(stripBlockIds('hello')).toBe('hello');
+      expect(stripBlockIds(42)).toBe(42);
     });
   });
 });

--- a/ai-translations/src/utils/translation/ItemsDropdownUtils.ts
+++ b/ai-translations/src/utils/translation/ItemsDropdownUtils.ts
@@ -10,7 +10,10 @@ import {
 import { normalizeProviderError } from './ProviderErrors';
 import {
   type FieldTypeDictionary,
+  type FieldValidators,
+  findExactLocaleKey,
   getExactSourceValue,
+  isFieldRequired,
   prepareFieldTypePrompt,
 } from './SharedFieldUtils';
 // no specific ctx type required here; we accept a minimal ctx shape
@@ -692,6 +695,30 @@ export async function buildTranslatedUpdatePayload(
     Promise.resolve(),
   );
 
+  // Ensure ALL localized fields have the target locale in the payload.
+  // DatoCMS requires every localized field to include a value for a new locale
+  // (the Locale Sync Rule). Fields that weren't translated still need the
+  // target locale key — use null for optional fields, source value for required.
+  for (const [field, meta] of Object.entries(fieldTypeDictionary)) {
+    if (!meta.isLocalized) continue;
+    if (updatePayload[field]) continue;
+
+    const fieldData = (record[field] as Record<string, unknown>) ?? {};
+    const existingTargetKey = findExactLocaleKey(fieldData, toLocale);
+    if (existingTargetKey !== undefined) continue;
+
+    const sourceValue = getExactSourceValue(fieldData, fromLocale);
+    const fallbackValue =
+      isFieldRequired(meta.validators) && sourceValue != null
+        ? sourceValue
+        : null;
+
+    updatePayload[field] = {
+      ...fieldData,
+      [toLocale]: fallbackValue,
+    };
+  }
+
   return {
     payload: updatePayload,
     translatedFieldCount,
@@ -771,12 +798,14 @@ export async function buildFieldTypeDictionary(
         appearance: { editor: string };
         id: string;
         localized: boolean;
+        validators: FieldValidators;
       },
     ) => {
       acc[field.api_key] = {
         editor: field.appearance.editor,
         id: field.id,
         isLocalized: field.localized,
+        validators: field.validators,
       };
       return acc;
     },

--- a/ai-translations/src/utils/translation/ItemsDropdownUtils.ts
+++ b/ai-translations/src/utils/translation/ItemsDropdownUtils.ts
@@ -582,6 +582,42 @@ export async function translateAndUpdateRecords(
 }
 
 /**
+ * Recursively strips `id` from DatoCMS block objects so the value can be
+ * copied to a new locale without creating duplicate-ID references.
+ *
+ * A DatoCMS block in nested response format looks like:
+ *   { type: "item", id: "abc123", attributes: { ... }, relationships: { ... } }
+ *
+ * Stripping the `id` tells the CMA to create a fresh block instance.
+ * Non-block values (strings, numbers, file references, etc.) pass through
+ * unchanged. Arrays and nested objects are recursed into so that deeply
+ * nested blocks (e.g., modular content inside a block) are also handled.
+ */
+export function stripBlockIds(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+
+  if (Array.isArray(value)) {
+    return value.map(stripBlockIds);
+  }
+
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+
+    // Detect a DatoCMS block: { type: "item", id: "..." }
+    const isBlock = obj.type === 'item' && typeof obj.id === 'string';
+
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(obj)) {
+      if (isBlock && key === 'id') continue;
+      result[key] = stripBlockIds(val);
+    }
+    return result;
+  }
+
+  return value;
+}
+
+/**
  * Builds an update payload with translated values for an API-fetched record.
  *
  * Context: table/bulk actions using CMA records (client.items.*). Returns a
@@ -699,6 +735,15 @@ export async function buildTranslatedUpdatePayload(
   // DatoCMS requires every localized field to include a value for a new locale
   // (the Locale Sync Rule). Fields that weren't translated still need the
   // target locale key — use null for optional fields, source value for required.
+  // For required block fields, copy source blocks with IDs stripped so DatoCMS
+  // creates fresh block instances for the new locale.
+  const blockEditorTypes = new Set([
+    'rich_text',
+    'structured_text',
+    'framed_single_block',
+    'frameless_single_block',
+  ]);
+
   for (const [field, meta] of Object.entries(fieldTypeDictionary)) {
     if (!meta.isLocalized) continue;
     if (updatePayload[field]) continue;
@@ -708,10 +753,16 @@ export async function buildTranslatedUpdatePayload(
     if (existingTargetKey !== undefined) continue;
 
     const sourceValue = getExactSourceValue(fieldData, fromLocale);
-    const fallbackValue =
-      isFieldRequired(meta.validators) && sourceValue != null
-        ? sourceValue
-        : null;
+    const isRequired =
+      isFieldRequired(meta.validators) && sourceValue != null;
+    const isBlockField = blockEditorTypes.has(meta.editor);
+
+    let fallbackValue: unknown = null;
+    if (isRequired && isBlockField) {
+      fallbackValue = stripBlockIds(sourceValue);
+    } else if (isRequired) {
+      fallbackValue = sourceValue;
+    }
 
     updatePayload[field] = {
       ...fieldData,

--- a/ai-translations/src/utils/translation/SharedFieldUtils.test.ts
+++ b/ai-translations/src/utils/translation/SharedFieldUtils.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { isFieldExcluded, normalizeTranslatedSlug } from './SharedFieldUtils';
+import {
+  isFieldExcluded,
+  isFieldRequired,
+  normalizeTranslatedSlug,
+} from './SharedFieldUtils';
 
 describe('SharedFieldUtils', () => {
   describe('normalizeTranslatedSlug', () => {
@@ -38,6 +42,17 @@ describe('SharedFieldUtils', () => {
       expect(isFieldExcluded(['details.en.slug'], ['field-id-1', 'slug'])).toBe(
         true,
       );
+    });
+  });
+
+  describe('isFieldRequired', () => {
+    it('returns true when validators contain the required key', () => {
+      expect(isFieldRequired({ required: {} })).toBe(true);
+    });
+
+    it('returns false when validators are empty or missing required', () => {
+      expect(isFieldRequired({})).toBe(false);
+      expect(isFieldRequired(undefined)).toBe(false);
     });
   });
 });

--- a/ai-translations/src/utils/translation/SharedFieldUtils.ts
+++ b/ai-translations/src/utils/translation/SharedFieldUtils.ts
@@ -3,14 +3,23 @@
  * Small, side-effect-free helpers shared by form and CMA flows.
  */
 
+import type { ApiTypes } from '@datocms/cma-client-browser';
 import { fieldPrompt } from '../../prompts/FieldPrompts';
+
+/** Union of all per-field-type validator shapes from the CMA client. */
+export type FieldValidators = ApiTypes.Field['validators'];
 
 /**
  * Field metadata dictionary keyed by field API key.
  */
 export type FieldTypeDictionary = Record<
   string,
-  { editor: string; id: string; isLocalized: boolean }
+  {
+    editor: string;
+    id: string;
+    isLocalized: boolean;
+    validators?: FieldValidators;
+  }
 >;
 
 /**
@@ -137,6 +146,17 @@ export function prepareFieldTypePrompt(fieldType: string): string {
     fieldTypePrompt += fieldPrompt[fieldType as keyof typeof fieldPrompt] || '';
   }
   return fieldTypePrompt;
+}
+
+/**
+ * Checks whether a field's validators include the `required` constraint.
+ *
+ * @param validators - The validators object from a field's schema metadata.
+ * @returns True when the field is required.
+ */
+export function isFieldRequired(validators: FieldValidators | undefined): boolean {
+  if (!validators) return false;
+  return 'required' in validators;
 }
 
 /**


### PR DESCRIPTION
## Fix: Include all localized fields when translating into a new locale (Locale Sync Rule)

### Problem

When translating a record into a locale that doesn't yet exist on that record, DatoCMS enforces the **Locale Sync Rule**: the update payload must include **every** localized field with a value for the new locale, not just the fields being translated. The plugin was only sending translated fields, causing `INVALID_LOCALES` / `INVALID_FIELD` 422 errors from the API:

```
In order to update this field adding new translations, you need to include
all other localized fields and explicitly provide a starting value (null is
acceptable) for each new locale: ["fr-CA"].
```

This affected the CMA-based bulk/dropdown translation flow (`client.items.update`). The sidebar form flow (`ctx.setFieldValue`) was not affected since it operates on individual fields in an already-open editor.

### Root cause

`buildTranslatedUpdatePayload()` in `ItemsDropdownUtils.ts` only added fields to the update payload if they passed `shouldTranslateField()` — meaning they had to be a translatable type, not excluded, and have source content. Localized fields that failed any of those checks were omitted entirely from the payload, violating the Locale Sync Rule.

### Fix

After the translation loop, a new fallback pass iterates **all** localized fields from the field type dictionary. Any field not already in the payload and missing the target locale key gets added with:

- **`null`** for optional fields (any type)
- **A copy of the source locale's value** for required non-block fields (determined via the field's `validators.required` constraint)
- **A copy of the source locale's value with block IDs stripped** for required block-based fields (rich_text, structured_text, single_block) — the recursive `stripBlockIds()` function removes `id` from every `{ type: "item", id: "..." }` object so DatoCMS creates fresh block instances for the new locale

Fields that already have the target locale are skipped, so existing translations are never overwritten.

### Compatibility with DatoCMS update rules

| Rule | Status |
|------|--------|
| **Rule 1** — send all locales when updating a field | ✅ All existing locales preserved via spread (`...fieldData`) |
| **Rule 2** — send all localized fields when adding a locale | ✅ This is the core fix |
| **Rule 3** — limited permissions send only managed locales | ⚠️ Same as existing behavior (not a regression) |
| **Block field IDs** — block IDs are locale-specific | ✅ Required block fields get source blocks with IDs recursively stripped; optional block fields get `null` |
| **Non-localized fields** — can be omitted | ✅ Only localized fields are processed |

### Changes

| File | Change |
|------|--------|
| `SharedFieldUtils.ts` | Added `FieldValidators` type (extracted from `ApiTypes.Field['validators']`), added it to `FieldTypeDictionary`, added `isFieldRequired()` helper |
| `ItemsDropdownUtils.ts` | Added `stripBlockIds()` recursive helper and locale sync fallback loop in `buildTranslatedUpdatePayload()`; updated `buildFieldTypeDictionary()` to include `validators` in field metadata |
| `schemaRepository.ts` | Updated `BlockFieldMeta` and `buildFieldTypeDictionaryFromRepo()` to use typed `validators` |
| `SharedFieldUtils.test.ts` | Added tests for `isFieldRequired()` |
| `ItemsDropdownUtils.test.ts` | Updated existing tests to expect locale-synced payloads; added tests for required field copy, required block field ID stripping, existing-locale skip behavior, and `stripBlockIds()` unit tests |

## Before
<img width="754" height="454" alt="image" src="https://github.com/user-attachments/assets/19d18708-012d-435e-a5b9-8cce4147a2dd" />

## After
![2026-04-09 11-50-47 AM](https://github.com/user-attachments/assets/fb2dbb81-4108-45bc-a526-95b85030aa52)
