### PR TITLE
Fix for record-comments CMA client targeting primary env instead of current.

### DIFF
--- a/record-comments/README.md
+++ b/record-comments/README.md
@@ -60,6 +60,11 @@ To enable realtime updates:
 - Ensure the current user can create and inspect models/fields in the project
 - Reload the plugin after permissions are fixed so it can verify the internal `project_comment` model
 
+## Changelog
+
+- 1.0.12: Fix using the plugin in an environment other than primary
+- 1.0.11 and prior: No changelog kept
+
 ## Support
 
 - [DatoCMS Documentation](https://www.datocms.com/docs)

--- a/record-comments/package.json
+++ b/record-comments/package.json
@@ -1,7 +1,7 @@
 {
   "name": "datocms-plugin-record-comments",
   "homepage": "https://github.com/datocms/plugins/tree/master/record-comments#readme",
-  "version": "1.0.11",
+  "version": "1.1.12",
   "author": "DatoCMS <support@datocms.com>",
   "description": "A plugin that allows you and your project collaborators to leave comments under a record",
   "keywords": [

--- a/record-comments/src/entrypoints/CommentsBar.tsx
+++ b/record-comments/src/entrypoints/CommentsBar.tsx
@@ -86,7 +86,10 @@ const CommentsBar = ({ ctx }: Props) => {
     realTimeRequested,
   ]);
 
-  const client = useMemo(() => createApiClient(cmaToken), [cmaToken]);
+  const client = useMemo(
+    () => createApiClient(cmaToken, ctx.environment),
+    [cmaToken, ctx.environment],
+  );
   const { projectUsers, projectModels, modelFields, typedUsers } =
     useProjectData(ctx, { loadFields: true });
   const { canMentionAssets, canMentionModels, readableModels } =

--- a/record-comments/src/entrypoints/ConfigScreen.tsx
+++ b/record-comments/src/entrypoints/ConfigScreen.tsx
@@ -318,8 +318,11 @@ const ConfigScreen = ({ ctx }: PropTypes) => {
 
   const getClient = useCallback(() => {
     if (!ctx.currentUserAccessToken) return null;
-    return buildClient({ apiToken: ctx.currentUserAccessToken });
-  }, [ctx.currentUserAccessToken]);
+    return buildClient({
+      apiToken: ctx.currentUserAccessToken,
+      environment: ctx.environment,
+    });
+  }, [ctx.currentUserAccessToken, ctx.environment]);
 
   const scanSingleModel = useCallback(
     async (

--- a/record-comments/src/entrypoints/utils/apiClient.ts
+++ b/record-comments/src/entrypoints/utils/apiClient.ts
@@ -2,7 +2,8 @@ import { buildClient, type Client } from '@datocms/cma-client-browser';
 
 export function createApiClient(
   token: string | null | undefined,
+  environment?: string,
 ): Client | null {
   if (!token) return null;
-  return buildClient({ apiToken: token });
+  return buildClient({ apiToken: token, environment });
 }

--- a/record-comments/src/main.tsx
+++ b/record-comments/src/main.tsx
@@ -62,7 +62,7 @@ connect({
           hasAccessToken: !!ctx.currentUserAccessToken,
         },
       );
-      ctx.notice(
+      await ctx.alert(
         'Comments plugin initialization warning: Unable to verify comment storage. ' +
           'If this is your first time using the plugin, please check your permissions.',
       );

--- a/record-comments/src/utils/commentsStorage.ts
+++ b/record-comments/src/utils/commentsStorage.ts
@@ -114,6 +114,9 @@ export async function ensureCommentsModelExists(
 ): Promise<string | null> {
   if (!ctx.currentUserAccessToken) return null;
 
-  const client = buildClient({ apiToken: ctx.currentUserAccessToken });
+  const client = buildClient({
+    apiToken: ctx.currentUserAccessToken,
+    environment: ctx.environment,
+  });
   return ensureCommentsModelExistsWithClient(client);
 }


### PR DESCRIPTION
Fixes #139  

Fix for record-comments CMA client targeting primary env instead of current.

  buildClient() without an environment parameter defaults to the primary
  environment. When the primary env is write-protected, plugin installation
  in secondary environments fails because model creation targets the
  locked primary. Pass ctx.environment to all buildClient call sites.

  Also fix onBoot error notification using ctx.notice instead of ctx.alert.