### PR TITLE
[shopify] Fix product image URLs and bump version

### DIFF
--- a/shopify-product/README.md
+++ b/shopify-product/README.md
@@ -37,12 +37,14 @@ If you hook it to a JSON field, it will save a JSON containing all the product's
     "edges": [
       {
         "node": {
-          "src": "https://cdn.shopify.com/s/files/1/1312/0893/products/001_39681e15-ce94-48ca-830f-980b11868856_200x200_crop_center.jpg?v=1491851133"
+          "src": "https://cdn.shopify.com/s/files/1/1312/0893/products/001_39681e15-ce94-48ca-830f-980b11868856.jpg?v=1491851133",
+          "previewSrc": "https://cdn.shopify.com/s/files/1/1312/0893/products/001_39681e15-ce94-48ca-830f-980b11868856_200x200.jpg?v=1491851133"
         }
       }
     ]
   },
-  "imageUrl": "https://cdn.shopify.com/s/files/1/1312/0893/products/001_39681e15-ce94-48ca-830f-980b11868856_200x200_crop_center.jpg?v=1491851133"
+  "imageUrl": "https://cdn.shopify.com/s/files/1/1312/0893/products/001_39681e15-ce94-48ca-830f-980b11868856.jpg?v=1491851133",
+  "previewImageUrl": "https://cdn.shopify.com/s/files/1/1312/0893/products/001_39681e15-ce94-48ca-830f-980b11868856_200x200.jpg?v=1491851133"
 }
 ```
 
@@ -52,3 +54,9 @@ To request a Storefront API access token follow [these instructions](https://www
 
 Remember to give products read permissions.
 ![Demo](https://raw.githubusercontent.com/datocms/plugins/master/shopify-product/docs/shopify-storefront-key.png)
+
+## Changelog
+
+### 1.0.9
+
+- New selections save full-size `imageUrl` plus `previewImageUrl` for the 200x200 preview. Existing JSON field values are not rewritten; reselect products or update stored JSON to refresh old `_200x200` `imageUrl` values.

--- a/shopify-product/README.md
+++ b/shopify-product/README.md
@@ -57,6 +57,6 @@ Remember to give products read permissions.
 
 ## Changelog
 
-### 1.0.9
+### 1.0.10
 
 - New selections save full-size `imageUrl` plus `previewImageUrl` for the 200x200 preview. Existing JSON field values are not rewritten; reselect products or update stored JSON to refresh old `_200x200` `imageUrl` values.

--- a/shopify-product/package-lock.json
+++ b/shopify-product/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datocms-plugin-shopify-product",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-plugin-shopify-product",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "ISC",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^7.2.0",

--- a/shopify-product/package-lock.json
+++ b/shopify-product/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datocms-plugin-shopify-product",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-plugin-shopify-product",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "ISC",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^7.2.0",
@@ -1672,6 +1672,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/cross-env": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
@@ -2746,15 +2755,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/zustand": {
       "version": "5.0.12",

--- a/shopify-product/package.json
+++ b/shopify-product/package.json
@@ -4,7 +4,7 @@
   "description": "A plugin that allows users to search and select Shopify products",
   "author": "DatoCMS <support@datocms.com>",
   "license": "ISC",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "keywords": [
     "datocms",
     "datocms-plugin",

--- a/shopify-product/package.json
+++ b/shopify-product/package.json
@@ -4,7 +4,7 @@
   "description": "A plugin that allows users to search and select Shopify products",
   "author": "DatoCMS <support@datocms.com>",
   "license": "ISC",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "keywords": [
     "datocms",
     "datocms-plugin",

--- a/shopify-product/src/components/BrowseProductsModal/index.tsx
+++ b/shopify-product/src/components/BrowseProductsModal/index.tsx
@@ -94,7 +94,9 @@ export default function BrowseProductsModal({ ctx }: { ctx: RenderModalCtx }) {
                 >
                   <div
                     className={s.product__image}
-                    style={{ backgroundImage: `url(${product.imageUrl})` }}
+                    style={{
+                      backgroundImage: `url(${product.previewImageUrl || product.imageUrl})`,
+                    }}
                   />
                   <div className={s.product__content}>
                     <div className={s.product__title}>{product.title}</div>

--- a/shopify-product/src/components/Value/index.tsx
+++ b/shopify-product/src/components/Value/index.tsx
@@ -61,7 +61,9 @@ export default function Value({ value, onReset }: ValueProps) {
         <div className={s.product}>
           <div
             className={s.product__image}
-            style={{ backgroundImage: `url(${product.imageUrl})` }}
+            style={{
+              backgroundImage: `url(${product.previewImageUrl || product.imageUrl})`,
+            }}
           />
           <div className={s.product__info}>
             <div className={s.product__title}>

--- a/shopify-product/src/utils/ShopifyClient.ts
+++ b/shopify-product/src/utils/ShopifyClient.ts
@@ -8,18 +8,18 @@ export type Product = {
   productType: string;
   onlineStoreUrl: string;
   imageUrl: string;
+  previewImageUrl: string;
   priceRange: {
     maxVariantPrice: PriceTypes;
     minVariantPrice: PriceTypes;
   };
   images: {
-    edges: [
-      {
-        node: {
-          src: string;
-        };
-      },
-    ];
+    edges: Array<{
+      node: {
+        src: string;
+        previewSrc: string;
+      };
+    }>;
   };
 };
 
@@ -53,15 +53,16 @@ const productFragment = `
   images(first: 1) {
     edges {
       node {
-        src: transformedSrc(maxWidth: 200, maxHeight: 200)
+        src
+        previewSrc: transformedSrc(maxWidth: 200, maxHeight: 200)
       }
     }
   }
 `;
 
-type RawProductNode = Omit<Product, 'imageUrl'> & {
+type RawProductNode = Omit<Product, 'imageUrl' | 'previewImageUrl'> & {
   images: {
-    edges: Array<{ node: { src: string } }>;
+    edges: Array<{ node: { src: string; previewSrc: string } }>;
   };
 };
 
@@ -77,6 +78,10 @@ const normalizeProduct = (product: RawProductNode): Product => {
   return {
     ...product,
     imageUrl: product.images.edges[0]?.node.src || '',
+    previewImageUrl:
+      product.images.edges[0]?.node.previewSrc ||
+      product.images.edges[0]?.node.src ||
+      '',
   };
 };
 


### PR DESCRIPTION
## Summary
- Save full-size Shopify image URLs in JSON field values
- Use 200x200 transformed images only for the plugin UI preview
- Bump Shopify plugin version to 1.0.9

Basically we were running into an issue where the `imageUrl` that comes back from the GraphQL response would have the `_200x200` suffix. Desired for the modal selection but not for the front end because its too smol.