### PR TITLE
[AI-Translations] Fix Anthropic Claude CORS error and change max_tokens

### DIFF
--- a/ai-translations/src/utils/translation/providers/AnthropicProvider.ts
+++ b/ai-translations/src/utils/translation/providers/AnthropicProvider.ts
@@ -85,6 +85,7 @@ export default class AnthropicProvider implements TranslationProvider {
         'content-type': 'application/json',
         'x-api-key': this.apiKey,
         'anthropic-version': '2023-06-01',
+        'anthropic-dangerous-direct-browser-access': 'true',
       },
       body: JSON.stringify(body),
       signal,
@@ -152,7 +153,7 @@ export default class AnthropicProvider implements TranslationProvider {
 
     const body: Record<string, unknown> = {
       model: this.model,
-      max_output_tokens: this.maxOutputTokens,
+      max_tokens: this.maxOutputTokens,
       temperature: this.temperature,
       messages: [{ role: 'user', content: prompt }],
     };


### PR DESCRIPTION
Claude cannot run in DatoCMS because of a CORS error, for this we add a header to allow CORS.

Also, there is no max_output_tokens value in the Claude API docs, currently it errors with a missing max tokens parameter, so changed this as well.